### PR TITLE
feat: Remove findDOMNode

### DIFF
--- a/src/MutateObserver.tsx
+++ b/src/MutateObserver.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import useEvent from 'rc-util/lib/hooks/useEvent';
 import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 import { supportRef, useComposeRef } from 'rc-util/lib/ref';
-import findDOMNode from 'rc-util/lib/Dom/findDOMNode';
-import useEvent from 'rc-util/lib/hooks/useEvent';
-import DomWrapper from './wrapper';
+import React from 'react';
 import type { MutationObserverProps } from './interface';
 import useMutateObserver from './useMutateObserver';
+import DomWrapper from './wrapper';
 
 const MutateObserver: React.FC<MutationObserverProps> = props => {
   const { children, options, onMutate = () => {} } = props;
@@ -23,17 +22,15 @@ const MutateObserver: React.FC<MutationObserverProps> = props => {
     canRef ? (children as any).ref : null,
   );
 
-  const [target, setTarget] = React.useState<HTMLElement>(null);
+  const [target, setTarget] = React.useState<HTMLElement | DomWrapper>(null);
 
-  useMutateObserver(target, callback, options);
+  useMutateObserver(target as HTMLElement, callback, options);
 
   // =========================== Effect ===========================
   // Bind target
   useLayoutEffect(() => {
-    setTarget(
-      findDOMNode(elementRef.current) || findDOMNode(wrapperRef.current),
-    );
-  });
+    setTarget(elementRef?.current || wrapperRef?.current);
+  }, []);
 
   // =========================== Render ===========================
   if (!children) {

--- a/src/useMutateObserver.tsx
+++ b/src/useMutateObserver.tsx
@@ -2,35 +2,35 @@ import canUseDom from 'rc-util/lib/Dom/canUseDom';
 import * as React from 'react';
 
 const defaultOptions: MutationObserverInit = {
-  subtree: true,
-  childList: true,
-  attributeFilter: ['style', 'class'],
+    subtree: true,
+    childList: true,
+    attributeFilter: ['style', 'class'],
 };
 
 export default function useMutateObserver(
-  nodeOrList: HTMLElement | HTMLElement[],
-  callback: MutationCallback,
-  options: MutationObserverInit = defaultOptions,
+    nodeOrList: HTMLElement | HTMLElement[],
+    callback: MutationCallback,
+    options: MutationObserverInit = defaultOptions,
 ) {
-  React.useEffect(() => {
-    if (!canUseDom() || !nodeOrList) {
-      return;
-    }
+    React.useEffect(() => {
+        if (!canUseDom() || !nodeOrList) {
+            return;
+        }
 
-    let instance: MutationObserver;
+        let instance: MutationObserver;
 
-    const nodeList = Array.isArray(nodeOrList) ? nodeOrList : [nodeOrList];
+        const nodeList = Array.isArray(nodeOrList) ? nodeOrList : [nodeOrList];
 
-    if ('MutationObserver' in window) {
-      instance = new MutationObserver(callback);
+        if ('MutationObserver' in window) {
+            instance = new MutationObserver(callback);
 
-      nodeList.forEach(element => {
-        instance.observe(element, options);
-      });
-    }
-    return () => {
-      instance?.takeRecords();
-      instance?.disconnect();
-    };
-  }, [options, nodeOrList]);
+            nodeList.forEach(element => {
+                instance.observe(element, options);
+            });
+        }
+        return () => {
+            instance?.takeRecords();
+            instance?.disconnect();
+        };
+    }, [options, nodeOrList]);
 }

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
 import MutateObserver from '../src';
 
 describe('MutateObserver', () => {
@@ -26,35 +26,5 @@ describe('MutateObserver', () => {
       expect(fn).not.toHaveBeenCalled();
     }
     unmount();
-  });
-
-  it('findDOMNode should not error in React.StrictMode', () => {
-    const fn = jest.fn();
-    const buttonRef = React.createRef<HTMLButtonElement>();
-    const warnSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const Demo = React.forwardRef<
-      HTMLButtonElement,
-      React.HTMLAttributes<HTMLButtonElement>
-    >((props, ref) => {
-      const [flag, setFlag] = React.useState<boolean>(true);
-      return (
-        <React.StrictMode>
-          <MutateObserver onMutate={fn}>
-            <button
-              {...props}
-              ref={ref}
-              className={flag ? 'aaa' : 'bbb'}
-              onClick={() => setFlag(!flag)}
-            >
-              click
-            </button>
-          </MutateObserver>
-        </React.StrictMode>
-      );
-    });
-    const { container } = render(<Demo ref={buttonRef} />);
-    fireEvent.click(container.querySelector('button')!);
-    expect(warnSpy).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Issue: https://github.com/ant-design/ant-design/issues/52115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
	- 更新了 `MutateObserver` 组件中目标状态的类型定义
	- 简化了目标设置逻辑，移除了对 `findDOMNode` 的依赖

- **测试**
	- 移除了与 `findDOMNode` 相关的测试用例
	- 保留了检查 `onMutate` 属性功能的测试

- **代码风格**
	- 调整了 `useMutateObserver` 文件中的代码缩进，提高了代码可读性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->