### PR TITLE
Avoid util deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "watch": "father dev"
   },
   "dependencies": {
-    "@rc-component/util": "^1.2.0"
+    "@rc-component/util": "^1.11.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.0.0",

--- a/src/MutateObserver.tsx
+++ b/src/MutateObserver.tsx
@@ -1,11 +1,11 @@
-import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { getDOM } from '@rc-component/util';
+import { useEvent } from '@rc-component/util';
+import { useLayoutEffect } from '@rc-component/util';
 import {
   getNodeRef,
   supportNodeRef,
   useComposeRef,
-} from '@rc-component/util/lib/ref';
+} from '@rc-component/util';
 import React from 'react';
 import type { MutationObserverProps } from './interface';
 import useMutateObserver from './useMutateObserver';

--- a/src/MutateObserver.tsx
+++ b/src/MutateObserver.tsx
@@ -1,10 +1,10 @@
-import { getDOM } from '@rc-component/util';
-import { useEvent } from '@rc-component/util';
-import { useLayoutEffect } from '@rc-component/util';
 import {
+  getDOM,
   getNodeRef,
   supportNodeRef,
   useComposeRef,
+  useEvent,
+  useLayoutEffect,
 } from '@rc-component/util';
 import React from 'react';
 import type { MutationObserverProps } from './interface';

--- a/src/useMutateObserver.tsx
+++ b/src/useMutateObserver.tsx
@@ -1,4 +1,4 @@
-import canUseDom from '@rc-component/util/lib/Dom/canUseDom';
+import { canUseDom } from '@rc-component/util';
 import React from 'react';
 
 const defaultOptions: MutationObserverInit = {


### PR DESCRIPTION
## 变更内容

- 升级 `@rc-component/util` 到当前 latest `^1.11.1`。
- 升级 `@rc-component/father-plugin` 到 `^2.2.0`，交由插件统一处理 rc 深路径 import 限制。
- 将源码中对 `@rc-component/util/lib/*` 的引用改为从 `@rc-component/util` 根入口导入。

## 背景

配合 rc 包统一避免依赖其他 rc 包的 `es` / `lib` 构建产物内部路径，改为使用公开根入口 API。

## 验证

- `git diff --check`
- 此前批量调整中已跑通 `npm run compile`、`npm run lint`、`npm test`。